### PR TITLE
Update: signup 기능 업데이트

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("logout/", views.user_logout, name="logout"),
     path("signup/", views.signup, name="signup"),  # 회원가입 경로
     path("login_find/", views.login_find, name="login_find"),  # ID/PW 찾기 경로
+    path("check_user_id/", views.check_user_id, name="check_user_id"), # AJAX 요청 받는 아이디 중복 확인용
 ]

--- a/member/models.py
+++ b/member/models.py
@@ -13,7 +13,9 @@ class Member(models.Model):
                                             ("manager", "점주"), ("normal", "일반회원")])  # 회원 유형
     name = models.CharField(validators=[MinLengthValidator(2)], max_length=50)
     sex = models.CharField(max_length=1, choices=[('M', '남성'), ('F', '여성')], null=True, blank=True)  # 성별 (M/F)
-    age_group = models.PositiveSmallIntegerField(null=True, blank=True)  # 연령대 (20, 30, 40)
+    age_group = models.PositiveSmallIntegerField(
+        null=True, blank=True,
+        choices=[(10, "10대"), (20, "20대"), (30, "30대"), (40, "40대"), (50, "50대"), (60, "60대 이상")])  # 연령대 (20, 30, 40)
     phone_num = models.CharField(max_length=13)  # 전화번호
     member_password = models.CharField(validators=[MinLengthValidator(4)], max_length=20)  # 비밀번호
     email = models.EmailField()  # 이메일

--- a/templates/main/signup.html
+++ b/templates/main/signup.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>회원가입</title>
@@ -12,24 +12,31 @@
 </head>
 <body style="background-color: #FFFFFF">
     <div class="container">
-        <img src="{% static 'images/signup_text.png' %}" alt="text" class="logo-img">
-        <form method="post" action="{% url 'main:signup' %}">
+        <img src="{% static 'images/signup_text.png' %}" alt="회원가입" class="logo-img">
+        <form method="POST" action="{% url 'main:signup' %}">
             {% csrf_token %}
             <div class="mb-3">
                 <label for="user_id">* 아이디</label>
-                <div class="d-flex">
-                    <input type="text" name="user_id" id="user_id" class="form-control" placeholder="아이디 입력(4~12자)" required>
-                    <button type="button" id="check-username-btn" class="btn btn-secondary">중복확인</button>
+                <div class="input-group">
+                    <input type="text" name="user_id" id="user_id" class="form-control" size="15" maxlength="12"
+                           placeholder="아이디를 입력해 주세요." required>
+                    <button type="button" id="check-username-btn" class="btn btn-secondary">중복 확인</button>
                 </div>
-                <small id="username-check-result" style="color: red;"></small>
+                <small id="username-check-result" class="form-text"></small>
             </div>
+                        
             <div class="mb-3">
                 <label for="password1">* 비밀번호</label>
-                <input type="password" name="password1" id="password1" class="form-control" maxlength="12" placeholder="비밀번호 입력(영문자, 숫자 포함 4~12자리)" required>
+                <input type="password" name="password1" id="password1" class="form-control" size="15" maxlength="12"
+                    placeholder="비밀번호를 입력해 주세요." required>
+                <small id="password-check-result"></small>
             </div>
+            
             <div class="mb-3">
                 <label for="password2">* 비밀번호 확인</label>
-                <input type="password" name="password2" id="password2" class="form-control" maxlength="12" placeholder="비밀번호 재입력" required>
+                <input type="password" name="password2" id="password2" class="form-control" size="15" maxlength="12"
+                    placeholder="비밀번호 재입력" required>
+                <small id="password-match-result"></small>
             </div>
             <div class="mb-3">
                 <label for="name">* 이름</label>
@@ -37,68 +44,175 @@
             </div>
             <div class="mb-3">
                 <label for="phone_num">* 휴대폰 번호</label>
-                <input type="text" name="phone_num" id="phone_num" class="form-control" placeholder="(-)제외한 숫자만 입력해주세요" value="{{ phone_num|default:'' }}" required>
+                <input type="tel" name="phone_num" id="phone_num" class="form-control" placeholder="(-)제외한 숫자만 입력해주세요" value="{{ phone_num|default:'' }}" required>
             </div>
             <div class="mb-3">
-                <label for="profile" class="form-label">프로필</label>
+                <label for="profile" class="form-label">프로필사진</label>
                 <input class="form-control" type="file" id="profile" name="profile">
             </div>
             <div class="mb-3">
                 <label for="email">* 이메일</label>
                 <div class="d-flex">
-                    <input type="email" id="email" class="form-control" placeholder="이메일 아이디" required>
+                    <input type="text" id="email_id" class="form-control" placeholder="이메일 아이디" required>
                     <span class="mx-2">@</span>
-                    <select id="email_domain" class="form-control">
+                    <select id="email_domain" class="form-select">
+                        <option value="" disabled selected>도메인 선택</option>
                         <option value="naver.com">naver.com</option>
                         <option value="gmail.com">gmail.com</option>
                         <option value="daum.net">daum.net</option>
                         <option value="직접입력">직접입력</option>
                     </select>
-                    <input type="email" id="email_custom" class="form-control d-none" placeholder="직접입력">
+                    <input type="text" id="email_custom" class="form-control d-none" placeholder="직접입력">
                 </div>
                 <input type="hidden" name="email" id="email_full">
             </div>
-{#            <div class="mb-3">#}
-{#                <label for="email">* 이메일</label>#}
-{#                <input type="email" name="email" id="email" class="form-control" placeholder="이메일을 입력해주세요" value="{{ email|default:'' }}" required>#}
-{#            </div>#}
-        
-            <div class="d-flex">
-            <!-- 연령대 드롭다운 버튼  -->
-                <div class="dropdown me-1">
-                    <button id="ageDropdownBtn" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">연령대</button>
-                    <!-- 연령대 드롭다운 메뉴 -->
-                <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="#" onclick="setAge('10대')">10대</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setAge('20대')">20대</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setAge('30대')">30대</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setAge('40대')">40대</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setAge('50대')">50대</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setAge('60대 이상')">60대 이상</a></li>
-                </ul>
+
+            <div class="mb-3">
+                <label><strong>연령대</strong></label><br>
+                <input type="radio" name="age_group" value="10" required> 10대 &nbsp;
+                <input type="radio" name="age_group" value="20" required> 20대 &nbsp;
+                <input type="radio" name="age_group" value="30" required> 30대 &nbsp;
+                <input type="radio" name="age_group" value="40" required> 40대 &nbsp;
+                <input type="radio" name="age_group" value="50" required> 50대 &nbsp;
+                <input type="radio" name="age_group" value="60" required> 60대 이상 &nbsp;
             </div>
-        
-            <div class="btn-group">
-                <!-- 성별 드롭다운 버튼  -->
-                  <button id="genderDropdownBtn" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">성별</button>
-                <!-- 성별 드롭다운 메뉴 -->
-                <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="#" onclick="setSex('남성')">남성</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="setSex('여성')">여성</a></li>
-                </ul>
+
+            <div class="mb-3">
+                <label><strong>성별</strong></label><br>
+                <input type="radio" name="sex" value="M"> 남성
+                <input type="radio" name="sex" value="F"> 여성
             </div>
-            </div>
-        
+
                 <br>
-        
-            <!-- 이용약관, 개인정보동의서 설정 -->
+
+            <!-- 이용약관동의 -->
             <div class="form-check">
-                <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
-                <label class="form-check-label" for="flexCheckDefault">이용약관동의(필수)</label>
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault" required>
+                <p class="d-inline"><strong>이용약관동의</strong></p><p class="d-inline">(필수)</p>
             </div>
+            {# 이용약관동의 전문 #}
+            <div class="container mt-3">
+                <div class="terms-box border p-3" style="max-height: 150px; overflow-y: auto; background-color: #f8f9fa; border-radius: 5px;">
+                    <p class="d-inline"><strong>제 1 조 (목적)</strong></p>
+                    <p>이 약관은 BreadScanso(이하 "회사")가 제공하는 서비스 이용과 관련하여 회사와 이용자의 권리, 의무 및 책임 사항을 규정함을 목적으로 합니다.</p>
+
+                    <p><strong>제 2 조 (정의)</strong></p>
+                    <ul>
+                      <li>"서비스"란 회사가 제공하는 모든 웹사이트 및 관련 서비스(모바일 포함)를 의미합니다.</li>
+                      <li>"이용자"란 본 약관에 동의하고 서비스를 이용하는 모든 개인 또는 법인을 의미합니다.</li>
+                      <li>"회원"이란 회사에 개인정보를 제공하여 회원가입을 한 자를 의미합니다.</li>
+                      <li>"비회원"이란 회원가입 없이 서비스를 이용하는 자를 의미합니다.</li>
+                    </ul>
+
+                    <p><strong>제 3 조 (약관의 효력 및 변경)</strong></p>
+                    <p>1. 본 약관은 이용자가 동의한 시점부터 효력을 발생합니다.</p>
+                    <p>2. 회사는 필요한 경우 약관을 개정할 수 있으며, 변경된 약관은 서비스 내 공지사항을 통해 사전 공지합니다.</p>
+
+                    <p><strong>제 4 조 (회원가입 및 계정 관리)</strong></p>
+                    <p>1. 이용자는 회사가 정한 가입 양식에 따라 정보를 입력하고 동의함으로써 회원가입이 가능합니다.</p>
+                    <p>2. 회원은 본인의 계정 정보를 타인에게 공유, 양도, 대여할 수 없습니다.</p>
+                    <p>3. 회원 정보가 변경되었을 경우 즉시 수정해야 하며, 미수정으로 인한 문제에 대한 책임은 회원 본인에게 있습니다.</p>
+
+                    <p><strong>제 5 조 (서비스의 제공 및 변경)</strong></p>
+                    <p>1. 회사는 이용자에게 다음과 같은 서비스를 제공합니다.</p>
+                    <ul>
+                      <li>온라인 베이커리 예약 및 주문 서비스</li>
+                      <li>멤버십 및 리워드 프로그램</li>
+                      <li>커뮤니티 및 고객 리뷰 기능</li>
+                    </ul>
+                    <p>2. 회사는 필요에 따라 서비스의 일부를 변경할 수 있으며, 중요한 변경 사항은 사전에 공지합니다.</p>
+
+                    <p><strong>제 6 조 (서비스 이용 제한 및 해지)</strong></p>
+                    <p>1. 회원이 다음 각 호에 해당하는 경우 회사는 서비스 이용을 제한할 수 있습니다.</p>
+                    <ul>
+                      <li>가입 신청 시 허위 정보를 제공한 경우</li>
+                      <li>타인의 계정을 도용하거나 부정한 방법으로 서비스에 접근한 경우</li>
+                      <li>공공질서 및 미풍양속을 해치는 행위를 한 경우</li>
+                    </ul>
+
+                    <p><strong>제 7 조 (개인정보 보호)</strong></p>
+                    <p>1. 회사는 회원의 개인정보를 안전하게 보호하며, 관련 법령을 준수합니다.</p>
+                    <p>2. 개인정보 수집 및 이용에 대한 내용은 "개인정보처리방침"을 따릅니다.</p>
+
+                    <p><strong>제 8 조 (면책 조항)</strong></p>
+                    <p>1. 회사는 천재지변, 기술적 결함 등 불가항력적인 사유로 인해 서비스를 제공할 수 없는 경우 책임을 지지 않습니다.</p>
+                    <p>2. 이용자가 서비스 내 정보를 신뢰하여 발생한 손해에 대해서는 회사가 책임지지 않습니다.</p>
+
+                    <p><strong>제 9 조 (분쟁 해결)</strong></p>
+                    <p>1. 회사와 이용자 간 발생한 분쟁은 원만하게 해결하는 것을 원칙으로 합니다.</p>
+                    <p>2. 분쟁이 해결되지 않을 경우 대한민국 법률을 준거법으로 하며, 관할 법원은 회사의 본사 소재지를 따릅니다.</p>
+
+                    <p><strong>부칙</strong></p>
+                    <p>1. 본 약관은 2024년 2월 23일부터 적용됩니다.</p>
+                    <p>2. 이전 약관은 본 약관으로 대체됩니다.</p>
+                </div>
+            </div>
+            <br>
+            {# 개인정보처리방침 #}
             <div class="form-check">
-                <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked">
-                <label class="form-check-label" for="flexCheckChecked">개인정보처리방침(필수)</label>
+                <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked" required>
+                <p class="d-inline"><strong>개인정보처리방침</strong></p><p class="d-inline">(필수)</p>
+            </div>
+            {# 개인정보처리방침 전문 #}
+            <div class="container mt-3">
+                <div class="terms-box border p-3" style="max-height: 150px; overflow-y: auto; background-color: #f8f9fa; border-radius: 5px;">
+                    <p><strong>제 1 조 (총칙)</strong></p>
+                    <p>BreadScanso(이하 "회사")는 이용자의 개인정보를 중요하게 생각하며, 관련 법령을 준수하여 안전하게 관리하고 있습니다.</p>
+
+                    <p><strong>제 2 조 (수집하는 개인정보 항목 및 이용 목적)</strong></p>
+                    <p>회사는 다음과 같은 개인정보를 수집하며, 이에 대한 이용 목적은 다음과 같습니다.</p>
+                    <ul>
+                      <li><strong>필수 항목:</strong> 아이디, 비밀번호, 이름, 휴대폰 번호, 이메일</li>
+                      <li><strong>수집 목적:</strong> 회원가입 및 본인 확인, 서비스 이용 제공</li>
+                      <li><strong>선택 항목:</strong> 프로필 사진, 주소</li>
+                      <li><strong>수집 목적:</strong> 맞춤형 서비스 제공 및 고객지원</li>
+                    </ul>
+
+                    <p><strong>제 3 조 (개인정보 보유 및 이용 기간)</strong></p>
+                    <p>회사는 원칙적으로 개인정보 수집 및 이용 목적이 달성된 후에는 해당 정보를 즉시 파기합니다. 단, 관련 법령에 의해 일정 기간 보관해야 하는 경우는 아래와 같습니다.</p>
+                    <ul>
+                      <li>계약 또는 청약 철회 기록: 5년 (전자상거래법)</li>
+                      <li>대금 결제 및 재화 공급 기록: 5년 (전자상거래법)</li>
+                      <li>소비자의 불만 또는 분쟁 처리 기록: 3년 (전자상거래법)</li>
+                      <li>로그 기록 및 접속 기록: 3개월 (통신비밀보호법)</li>
+                    </ul>
+
+                    <p><strong>제 4 조 (개인정보의 제3자 제공)</strong></p>
+                    <p>회사는 이용자의 동의 없이 개인정보를 제3자에게 제공하지 않습니다. 단, 법령에 의거하여 관계 기관의 요청이 있는 경우 예외로 합니다.</p>
+
+                    <p><strong>제 5 조 (개인정보의 파기 절차 및 방법)</strong></p>
+                    <p>회사는 수집된 개인정보를 안전하게 처리하며, 다음과 같은 방법으로 파기합니다.</p>
+                    <ul>
+                      <li>전자적 파일 형태의 정보는 복구할 수 없는 기술적 방법을 사용하여 삭제</li>
+                      <li>종이 문서는 분쇄하거나 소각하여 폐기</li>
+                    </ul>
+
+                    <p><strong>제 6 조 (이용자의 권리 및 행사 방법)</strong></p>
+                    <p>이용자는 언제든지 자신의 개인정보를 조회하거나 수정할 수 있으며, 동의 철회 및 삭제를 요청할 수 있습니다.</p>
+                    <ul>
+                      <li>개인정보 수정: [내 정보] 페이지에서 직접 수정 가능</li>
+                      <li>회원 탈퇴 및 개인정보 삭제 요청: 고객센터를 통해 요청 가능</li>
+                    </ul>
+
+                    <p><strong>제 7 조 (개인정보 보호를 위한 기술적/관리적 대책)</strong></p>
+                    <p>회사는 개인정보 보호를 위해 다음과 같은 기술적, 관리적 조치를 취하고 있습니다.</p>
+                    <ul>
+                      <li>개인정보 암호화: 비밀번호는 암호화하여 저장 및 관리</li>
+                      <li>해킹 및 보안 대책: 방화벽 및 보안 시스템을 통해 개인정보 보호</li>
+                      <li>접근 제한: 개인정보 접근 권한을 최소화하여 관리</li>
+                    </ul>
+
+                    <p><strong>제 8 조 (개인정보 보호 책임자 및 연락처)</strong></p>
+                    <p>회사는 개인정보 보호를 위해 책임자를 지정하고 있으며, 관련 문의는 아래 연락처를 통해 가능합니다.</p>
+                    <ul>
+                      <li><strong>개인정보 보호 책임자:</strong> 브레드</li>
+                      <li><strong>이메일:</strong> privacy@breadscanso.com</li>
+                      <li><strong>전화번호:</strong> 1234-5678</li>
+                    </ul>
+
+                    <p><strong>제 9 조 (부칙)</strong></p>
+                    <p>본 개인정보처리방침은 2024년 2월 23일부터 적용됩니다.</p>
+                </div>
             </div>
             <br>
             
@@ -107,294 +221,148 @@
             {% endif %}
             
             <button type="submit" class="btn btn-primary">가입하기</button>
+            <br>
+            <br>
+        <p class="d-inline">이미 계정이 있으신가요?</p>
+        <a href="{% url 'main:login' %}" class="btn btn-outline-secondary d-inline" role="button">로그인</a>
         </form>
-        <a href="{% url 'main:login' %}">이미 계정이 있으신가요? 로그인</a>
     </div>
 
     <script>
-    document.getElementById("check-username-btn").addEventListener("click", function() {
-        let userId = document.getElementById("user_id").value;
-        let resultBox = document.getElementById("username-check-result");
-
-        if (userId.length < 4 || userId.length > 12) {
-            resultBox.style.color = "red";
-            resultBox.innerText = "아이디는 4~12자여야 합니다.";
-            return;
-        }
-
-        fetch(`/main/check_user_id/?user_id=${userId}`)
-            .then(response => response.json())
-            .then(data => {
-                if (data.exists) {
-                    resultBox.style.color = "red";
-                    resultBox.innerText = "이미 사용 중인 아이디입니다.";
-                } else {
-                    resultBox.style.color = "green";
-                    resultBox.innerText = "사용 가능한 아이디입니다.";
-                }
-            })
-            .catch(error => console.error("Error:", error));
-    });
+        document.addEventListener("DOMContentLoaded", function() {
+            let userIdInput = document.getElementById("user_id");
+            let userIdResult = document.getElementById("username-check-result");
+            let checkUsernameBtn = document.getElementById("check-username-btn");
+            let signupBtn = document.querySelector("button[type='submit']"); // 회원가입 버튼
     
-    document.addEventListener("DOMContentLoaded", function() {
+            let isIdValid = false;  // 아이디 조건 만족 여부
+            let isIdUnique = false; // 중복 체크 완료 여부
+    
+            // 아이디 유효성 검사 (영소문자+숫자 4~12자리)
+            userIdInput.addEventListener("input", function() {
+                let userId = userIdInput.value;
+                let regex = /^[a-z0-9]{4,12}$/;
+    
+                if (!regex.test(userId)) {
+                    userIdResult.style.color = "red";
+                    userIdResult.innerText = "아이디는 영소문자/숫자 4~12자리여야 합니다.";
+                    isIdValid = false;
+                } else {
+                    userIdResult.style.color = "green";
+                    userIdResult.innerText = "사용 가능한 아이디입니다.";
+                    isIdValid = true;
+                }
+    
+                isIdUnique = false;  // 새 아이디 입력 시 중복 체크 다시
+                checkSignupButton();
+            });
+    
+            // 중복 확인 버튼 클릭 시 AJAX 요청
+            checkUsernameBtn.addEventListener("click", function() {
+                let userId = userIdInput.value;
+    
+                if (!isIdValid) {
+                    alert("아이디 조건을 먼저 충족해주세요.");
+                    return;
+                }
+    
+                fetch(`/main/check_user_id/?user_id=${userId}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.valid) {
+                            userIdResult.style.color = "gray";
+                            userIdResult.innerText = "사용 가능한 아이디입니다.";
+                            isIdUnique = true;
+                        } else {
+                            alert("중복된 아이디입니다.");
+                            userIdResult.style.color = "red";
+                            userIdResult.innerText = "중복된 아이디입니다.";
+                            isIdUnique = false;
+                        }
+                        checkSignupButton();
+                    })
+                    .catch(error => console.error("Error:", error));
+            });
+            
+            // '중복확인' 해야 가입 버튼 누를 수 있음.
+            function checkSignupButton() {
+                if (isIdValid && isIdUnique) {
+                    signupBtn.disabled = false;
+                } else {
+                    signupBtn.disabled = true;
+                }
+            }
+    
+            // 비밀번호 유효성 검사 (영문+숫자+특수문자 4~12자리)
+            let passwordInput = document.getElementById("password1");
+            let passwordResult = document.getElementById("password-check-result");
+    
+            passwordInput.addEventListener("input", function() {
+                let password = passwordInput.value;
+                let regex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[\W_]).{4,12}$/;
+    
+                if (!regex.test(password)) {
+                    passwordResult.style.color = "red";
+                    passwordResult.innerText = "영문자+숫자+특수문자 4~12자리여야 합니다.";
+                } else {
+                    passwordResult.style.color = "green";
+                    passwordResult.innerText = "사용 가능한 비밀번호입니다.";
+                }
+            });
+    
+            // 비밀번호 확인 (password1 == password2)
+            let passwordConfirmInput = document.getElementById("password2");
+            let passwordConfirmResult = document.getElementById("password-match-result");
+    
+            passwordConfirmInput.addEventListener("input", function() {
+                let password1 = passwordInput.value;
+                let password2 = passwordConfirmInput.value;
+    
+                if (password1 === password2) {
+                    passwordConfirmResult.style.color = "green";
+                    passwordConfirmResult.innerText = "비밀번호가 동일합니다.";
+                } else {
+                    passwordConfirmResult.style.color = "red";
+                    passwordConfirmResult.innerText = "비밀번호가 동일하지 않습니다.";
+                }
+            });
+        });
+
+        document.addEventListener("DOMContentLoaded", function() {
             let emailIdInput = document.getElementById("email_id");
             let emailDomainSelect = document.getElementById("email_domain");
             let emailCustomInput = document.getElementById("email_custom");
             let emailFullInput = document.getElementById("email_full");
     
             function updateEmail() {
-            let emailId = emailIdInput.value.trim();
-            let domain = emailDomainSelect.value;
+                let emailId = emailIdInput.value.trim();
+                let domain = emailDomainSelect.value;
     
-            if (domain === "직접입력") {
-            domain = emailCustomInput.value.trim();
-        }
+                if (domain === "직접입력") {
+                    domain = emailCustomInput.value.trim();
+                }
     
-            emailFullInput.value = emailId && domain ? `${emailId}@${domain}` : "";
-        }
+                emailFullInput.value = emailId && domain ? `${emailId}@${domain}` : "";
+            }
     
             emailIdInput.addEventListener("input", updateEmail);
+    
             emailDomainSelect.addEventListener("change", function() {
-            if (this.value === "직접입력") {
-            emailCustomInput.classList.remove("d-none");
-        } else {
-            emailCustomInput.classList.add("d-none");
-            emailCustomInput.value = "";
-        }
-            updateEmail();
-        });
+                if (this.value === "직접입력") {
+                    emailCustomInput.classList.remove("d-none");
+                    emailCustomInput.removeAttribute("disabled");
+                    emailCustomInput.focus();
+                } else {
+                    emailCustomInput.classList.add("d-none");
+                    emailCustomInput.setAttribute("disabled", "true");
+                    emailCustomInput.value = "";
+                }
+                updateEmail();
+            });
+    
             emailCustomInput.addEventListener("input", updateEmail);
         });
     </script>
 </body>
 </html>
 {% include 'layout/main/footer_main.html' %}
-
-
-
-
-
-
-
-{#{% load static %}#}
-{##}
-{#<!DOCTYPE html>#}
-{#<html lang="en">#}
-{#<head>#}
-{#    <meta charset="UTF-8">#}
-{#    <title>회원가입</title>#}
-{#    <link rel="stylesheet" href="{% static 'css/style.css' %}">#}
-{#    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">#}
-{#    <!-- Bootstrap CSS (필수) -->#}
-{#    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">#}
-{##}
-{#    <!-- Bootstrap JavaScript (필수) -->#}
-{#    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>#}
-{##}
-{#</head>#}
-{#<body class="main-index" style="background-color: #FFFFFF;">#}
-{#{% include 'layout/main/header_main.html' %}#}
-{#    <div class="container">#}
-{#            <img src="{% static 'images/signup_text.png' %}" alt="text" class="logo-img">#}
-{#        <form method="post">#}
-{#            {% csrf_token %}#}
-{#            <div class="mb-3">#}
-{#                <label for="user_id">* 아이디</label>#}
-{#                <input type="text" name="user_id" id="user_id" class="form-control" placeholder="아이디 입력(4~12자)" required>#}
-{#                <button type="button" class="btn btn-secondary" onclick="checkUser_id()">중복 확인</button>#}
-{#                <p id="user_id-result"></p>#}
-{##}
-{#            <script>#}
-{#                function checkUsername() {#}
-{#                    var user_id = document.getElementById("user_id").value;#}
-{#                    var resultElement = document.getElementById("user_id-result");#}
-{##}
-{#                    fetch("/check-user_id/", {#}
-{#                        method: "POST",#}
-{#                        headers: {#}
-{#                            "Content-Type": "application/x-www-form-urlencoded",#}
-{#                            "X-CSRFToken": getCSRFToken()#}
-{#                        },#}
-{#                        body: "user_id=" + encodeURIComponent(user_id)#}
-{#                    })#}
-{#                    .then(response => response.json())#}
-{#                    .then(data => {#}
-{#                        if (data.exists) {#}
-{#                            resultElement.innerText = "이미 사용 중인 아이디입니다.";#}
-{#                            resultElement.style.color = "red";#}
-{#                        } else {#}
-{#                            resultElement.innerText = "사용 가능한 아이디입니다!";#}
-{#                            resultElement.style.color = "green";#}
-{#                        }#}
-{#                    });#}
-{#                }#}
-{##}
-{#                // CSRF 토큰 가져오기 (Django 보안 정책 대응)#}
-{#                function getCSRFToken() {#}
-{#                    return document.cookie.split("; ")#}
-{#                        .find(row => row.startsWith("csrftoken="))#}
-{#                        ?.split("=")[1];#}
-{#                }#}
-{#            </script>#}
-{#        </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="password1">* 비밀번호</label>#}
-{#        <input type="password" name="password1" id="password1" class="form-control" placeholder="비밀번호 입력(영문자, 숫자 포함 4~12자리)" required>#}
-{#    </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="password2">* 비밀번호 확인</label>#}
-{#        <input type="password" name="password2" id="password2" class="form-control" placeholder="비밀번호 재입력" required>#}
-{#    </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="username">* 이름</label>#}
-{#        <input type="text" name="username" id="username" class="form-control" placeholder="이름" required>#}
-{#    </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="phone_num">* 휴대폰 번호</label>#}
-{#        <input type="number" name="phone_num" id="phone_num" class="form-control" placeholder="(-)제외한 숫자만 입력해주세요" required>#}
-{#    </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="profile" class="form-label">프로필</label>#}
-{#        <input class="form-control" type="file" id="profile" name="profile">#}
-{#    </div>#}
-{#    <div class="mb-3">#}
-{#        <label for="email">* 이메일</label>#}
-{#        <div class="d-flex">#}
-{#            <input type="text" id="email_id" class="form-control" placeholder="이메일 아이디" required>#}
-{#            <span class="mx-2">@</span>#}
-{#            <select id="email_domain" class="form-control">#}
-{#                <option value="naver.com">naver.com</option>#}
-{#                <option value="gmail.com">gmail.com</option>#}
-{#                <option value="daum.net">daum.net</option>#}
-{#                <option value="직접입력">직접입력</option>#}
-{#            </select>#}
-{#            <input type="text" id="email_custom" class="form-control d-none" placeholder="직접입력">#}
-{#        </div>#}
-{#        <input type="hidden" name="email" id="email_full">#}
-{#    </div>#}
-{#    <!-- 이메일 선택란 설정 -->#}
-{#    <script>#}
-{#        document.addEventListener("DOMContentLoaded", function() {#}
-{#        let emailIdInput = document.getElementById("email_id");#}
-{#        let emailDomainSelect = document.getElementById("email_domain");#}
-{#        let emailCustomInput = document.getElementById("email_custom");#}
-{#        let emailFullInput = document.getElementById("email_full");#}
-{##}
-{#        function updateEmail() {#}
-{#        let emailId = emailIdInput.value.trim();#}
-{#        let domain = emailDomainSelect.value;#}
-{##}
-{#        if (domain === "직접입력") {#}
-{#        domain = emailCustomInput.value.trim();#}
-{#    }#}
-{##}
-{#        emailFullInput.value = emailId && domain ? `${emailId}@${domain}` : "";#}
-{#    }#}
-{##}
-{#        emailIdInput.addEventListener("input", updateEmail);#}
-{#        emailDomainSelect.addEventListener("change", function() {#}
-{#        if (this.value === "직접입력") {#}
-{#        emailCustomInput.classList.remove("d-none");#}
-{#    } else {#}
-{#        emailCustomInput.classList.add("d-none");#}
-{#        emailCustomInput.value = "";#}
-{#    }#}
-{#        updateEmail();#}
-{#    });#}
-{#        emailCustomInput.addEventListener("input", updateEmail);#}
-{#    });#}
-{#</script>#}
-{##}
-{#            <br>#}
-{##}
-{#    <div class="d-flex">#}
-{#    <!-- 연령대 드롭다운 버튼  -->#}
-{#        <div class="dropdown me-1">#}
-{#            <button id="ageDropdownBtn" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">연령대</button>#}
-{#            <!-- 연령대 드롭다운 메뉴 -->#}
-{#        <ul class="dropdown-menu">#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('10대')">10대</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('20대')">20대</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('30대')">30대</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('40대')">40대</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('50대')">50대</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setAge('60대 이상')">60대 이상</a></li>#}
-{#        </ul>#}
-{#    </div>#}
-{##}
-{#    <div class="btn-group">#}
-{#        <!-- 성별 드롭다운 버튼  -->#}
-{#          <button id="genderDropdownBtn" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">성별</button>#}
-{#        <!-- 성별 드롭다운 메뉴 -->#}
-{#        <ul class="dropdown-menu">#}
-{#          <li><a class="dropdown-item" href="#" onclick="setSex('남성')">남성</a></li>#}
-{#          <li><a class="dropdown-item" href="#" onclick="setSex('여성')">여성</a></li>#}
-{#        </ul>#}
-{#    </div>#}
-{#    </div>#}
-{##}
-{#        <br>#}
-{##}
-{#    <!-- 이용약관, 개인정보동의서 설정 -->#}
-{#    <div class="form-check">#}
-{#        <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">#}
-{#        <label class="form-check-label" for="flexCheckDefault">이용약관동의(필수)</label>#}
-{#    </div>#}
-{#    <div class="form-check">#}
-{#        <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked">#}
-{#        <label class="form-check-label" for="flexCheckChecked">개인정보처리방침(필수)</label>#}
-{#    </div>#}
-{#    <br>#}
-{##}
-{#            {% if error %}#}
-{#                <div class="alert alert-danger">{{ error }}</div>#}
-{#            {% endif %}#}
-{#            <!-- 가입하기 버튼 -->#}
-{#            <button type="submit" id="signupButton" class="btn btn-primary">가입하기</button>#}
-{##}
-{#            <!-- 회원가입 완료 팝업창 -->#}
-{#            <div class="modal fade" id="signupSuccessModal" tabindex="-1" aria-labelledby="signupSuccessLabel" aria-hidden="true">#}
-{#                <div class="modal-dialog">#}
-{#                    <div class="modal-content">#}
-{#                        <div class="modal-header">#}
-{#                            <h5 class="modal-title" id="signupSuccessLabel">회원가입 완료</h5>#}
-{#                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>#}
-{#                        </div>#}
-{#                        <div class="modal-body">#}
-{#                            가입이 완료되었습니다.<br>저희 브레드 스캔소의 회원이 되어주셔서 감사합니다🧡#}
-{#                        </div>#}
-{#                        <div class="modal-footer">#}
-{#                            <button type="button" class="btn btn-secondary" id="confirmButton">확인</button>#}
-{#                        </div>#}
-{#                    </div>#}
-{#                </div>#}
-{#            </div>#}
-{#            <script>#}
-{#                document.addEventListener("DOMContentLoaded", function () {#}
-{#                    let signupForm = document.querySelector("form");  // 폼 선택#}
-{#                    let confirmButton = document.getElementById("confirmButton"); // 확인 버튼#}
-{##}
-{#                    signupForm.addEventListener("submit", function (event) {#}
-{#                        event.preventDefault(); // 기본 폼 제출 방지#}
-{##}
-{#                        // 가입 완료 팝업창 표시#}
-{#                        let modal = new bootstrap.Modal(document.getElementById("signupSuccessModal"));#}
-{#                        modal.show();#}
-{##}
-{#                        // 확인 버튼 클릭 시 홈 화면으로 이동#}
-{#                        confirmButton.addEventListener("click", function () {#}
-{#                            window.location.href = "/";  // 홈 페이지로 이동#}
-{#                        });#}
-{#                    });#}
-{#                });#}
-{#            </script>#}
-{##}
-{##}
-{#    </form>#}
-{#    <a href="{% url 'login' %}">이미 계정이 있으신가요? 로그인</a>#}
-{##}
-{#    </div>#}
-{#        {% include 'layout/main/footer_main.html' %}#}
-{##}
-{#</body>#}
-{#</html>#}


### PR DESCRIPTION
#180 

## 1. 아이디
### 아이디 유효성 검사
- [x] 영소문자/숫자로 구성된 4~12자리만 허용
- [x] 조건 충족 전에는 "아이디는 영소문자/숫자 4~12자리여야 합니다" 빨간색 글자로 안내
- [x] 조건 충족 시 "사용가능한 아이디입니다" 초록색 글자로 안내
### 중복 확인 버튼
- [x] 요구사항에 있는 실시간 AJAX 검사 시 안내글이 중복되는 문제 발생. -> "중복확인" 버튼 클릭 시 서버에서 중복 여부 확인하도록 설정.
- [x] 중복된 경우 alert "중복된 아이디입니다"
- [x] 중복되지 않은 경우 "사용 가능한 아이디입니다"
- [x] 중복확인 버튼 통과한 경우에만 '가입하기' 버튼 활성화
- [x] 버튼 위치 input-group으로 아이디 입력창과 나란히 있도록 설정

## 2. 비밀번호
### 비밀번호 유효성 검사 추가
- [x] 영문자+숫자+특수문자 포함 4~12자리만 허용
- [x] 조건 충족 전에는 "영문자+숫자+특수문자 4~12자리여야 합니다" 빨간색 글자로 안내
- [x] 조건 충족 시 "사용 가능한 비밀번호입니다" 초록색 글자로 안내
### 비밀번호 확인 검사 안내글 추가
- [x] password1, passord2가 일치할 경우 "비밀번호가 동일합니다" 초록색 안내글이 나오고, 불일치하면 "비밀번호가 동일하지 안흡니다" 빨간색 안내글이 나오게 설정
![유효성검사](https://github.com/user-attachments/assets/ecf97f05-3e80-4569-b9e1-ea5d763c2ec7)
![중복확인_alert](https://github.com/user-attachments/assets/ffddf37b-7276-490f-9ed0-9074ba9e6ae1)
![중복확인_비밀번호유효성검사](https://github.com/user-attachments/assets/0b5c0d74-7c25-470a-962f-03c960ffd69d)

## 3. 이메일
### 도메인 선택 드롭다운 수정
- [x] 기본적으로 "도메인 선택"이 표시됨
- [x] "직접입력" 선택 시 새로운 입력칸 활성화
- [x] 자동으로 hidden input에 이메일 완성되고, name="email" 필드에 저장됨
![도메인](https://github.com/user-attachments/assets/2cd84fd9-6633-490b-9132-05630a401c56)

## 4. 이용약관, 개인정보처리방침
- [x] bootstrap 모달 기능에 GPT로 제작한 이용약관, 개인정보처리방침 추가. 
