### PR TITLE
Feat: session에 member type 저장

### DIFF
--- a/breadscanso/urls.py
+++ b/breadscanso/urls.py
@@ -7,7 +7,7 @@ app_name = 'main'
 
 urlpatterns = [
     path('', views.index, name='index'),
-    path('main/', include('main.urls')),
+    path('main/', include('main.urls')), # 회원 관련 URL
     path('kiosk/', include('kiosk.urls')),  # kiosk 앱의 urls.py를 포함
     path('brand/', include('brand.urls')),  # brand 앱의 urls.py를 포함
     path('event/', include('event.urls')),  # event 앱의 urls.py를 포함

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path("signup/", views.signup, name="signup"),  # 회원가입 경로
     path("login_find/", views.login_find, name="login_find"),  # ID/PW 찾기 경로
     path("check_user_id/", views.check_user_id, name="check_user_id"), # AJAX 요청 받는 아이디 중복 확인용
+    path("sales/", include("sales.urls")), # sales 앱 URL 포함하기
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -40,6 +40,7 @@ def signup(request):
 
     return render(request, "main/signup.html")
 
+
 def user_login(request):
     if request.method == "POST":
         user_id = request.POST.get('user_id')
@@ -49,18 +50,30 @@ def user_login(request):
 
         if user is not None:
             login(request, user)
-            return redirect("/")
+
+            try:
+                member = Member.objects.get(user=user)
+
+                # 로그인한 사용자 정보를 세션에 저장
+                request.session['member_type'] = member.member_type
+                return redirect("main:index")
+
+            except Member.DoesNotExist:
+                messages.error(request, "회원 정보가 없습니다.")
+                return redirect("main:login")
         else:
             messages.error(request, "아이디 또는 비밀번호가 틀렸습니다.")
             return redirect("main:login")
 
     return render(request, "main/login.html")
 
+
+
 def user_logout(request):
     if request.method == "POST":  # post 요청만 허용
         logout(request)
         request.session.flush()  # 세션 삭제
-        return redirect("/")
+        return redirect("main:index")
     return HttpResponseNotAllowed(["POST"]) # get 허용 안 함
 
 

--- a/sales/urls.py
+++ b/sales/urls.py
@@ -1,5 +1,9 @@
 from django.urls import path
+
+from member.urls import app_name
 from . import views
+
+app_name= "sales"
 
 urlpatterns = [
     path('', views.sales_main, name='sales_main'),

--- a/store/views.py
+++ b/store/views.py
@@ -7,8 +7,26 @@ from django.db.models import Q
 from store.models import Question, QuestionForm, Answer
 from member.models import Member
 
+
 def store_main(request):
-    return render(request, 'store/store_main.html')  # /store/
+    if not request.user.is_authenticated:
+        return redirect("main:login")
+
+    try:
+        member = Member.objects.get(user=request.user)
+
+        # member_type이 none이면 'normal'로 간주
+        member_type = member.member_type if member.member_type else "normal"
+
+        # owner 또는 manager일 경우 매장페이지 첫화면(매출관리)으로 이동
+        if member_type in ["owner", "manager"]:
+            return redirect("sales:sales_main")
+
+        else:
+            return redirect("member:member_page")  # normal 회원은 마이페이지로 이동
+
+    except Member.DoesNotExist:
+        return redirect("main:index")
 
 # 점주 회원관리
 def member_store(request):

--- a/templates/layout/main/header_main.html
+++ b/templates/layout/main/header_main.html
@@ -2,7 +2,7 @@
 <body class="main-index">
     <header>
         <div class="text-end" style="background-color: #b3997d;">
-            <a href="{% url 'sales_main' %}" class="btn btn-light">매장페이지</a>
+            <a href="{% url 'sales:sales_main' %}" class="btn btn-light">매장페이지</a>
             <a href="{% url 'member:member_page' %}" class="btn btn-light">마이페이지</a>
         </div>
         <div class="logo-container" style="background-color: #b3997d;">

--- a/templates/layout/store/base_store.html
+++ b/templates/layout/store/base_store.html
@@ -76,7 +76,7 @@
                 </button>
                 <div class="collapse" id="sale_info">
                   <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                    <li><a href="{% url 'sales_main' %}" class="link-body-emphasis d-inline-flex text-decoration-none rounded">그래프</a></li>
+                    <li><a href="{% url 'sales:sales_main' %}" class="link-body-emphasis d-inline-flex text-decoration-none rounded">그래프</a></li>
                     <li><a href="#" class="link-body-emphasis d-inline-flex text-decoration-none rounded">매출</a></li>
                     <li><a href="#" class="link-body-emphasis d-inline-flex text-decoration-none rounded">AI챗봇</a></li>
                   </ul>

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -36,7 +36,7 @@
     <header>
         <div class="text-end" style="background-color: #b3997d;">
             <a href="{% url 'kiosk_main' %}" class="btn btn-light">KIOSK</a>
-            <a href="{% url 'sales_main' %}" class="btn btn-light">매장페이지</a>
+            <a href="{% url 'sales:sales_main' %}" class="btn btn-light">매장페이지</a>
             <a href="{% url 'member:member_page' %}" class="btn btn-light">마이페이지</a>
         </div>
         <div class="logo-container" style="background-color: #b3997d;">
@@ -56,12 +56,13 @@
                     <li><a class="dropdown-item" href="/qna">Q&A</a></li>
                 </ul>
             </div>
-
             {% if user.is_authenticated %}
-                <a href="{% url 'member:member_page' %}" class="btn btn-light">마이페이지</a>
-                
-                <!-- 로그아웃 버튼 (POST)-->
-                <form action="{% url 'main:logout' %}" method="POST" style="display: inline-block;">
+                {% if request.session.member_type == "owner" or request.session.member_type == "manager" %}
+                    <a href="{% url 'sales:sales_main' %}" class="btn btn-light">매장페이지</a>
+                {% else %}
+                    <a href="{% url 'member:member_page' %}" class="btn btn-light">마이페이지</a>
+                {% endif %}
+                <form action="{% url 'main:logout' %}" method="post">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-light">로그아웃</button>
                 </form>
@@ -126,149 +127,3 @@
 
 </body>
 </html>
-
-
-{#{% load static %}#}
-{##}
-{#<!DOCTYPE html>#}
-{#<html lang="en">#}
-{#<head>#}
-{#    <meta charset="UTF-8">#}
-{#    <title>BreadScanco | index</title>#}
-{#    <link rel="stylesheet" href="{% static 'css/style.css' %}">#}
-{#    <!-- Bootstrap CSS -->#}
-{#    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">#}
-{#    <!-- Bootstrap JS, Popper.js, and jQuery (필수) -->#}
-{#<!--    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>-->#}
-{#<!--    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"></script>-->#}
-{#    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>#}
-{##}
-{#</head>#}
-{#<body class="main-index">#}
-{#    <header>#}
-{#    <div class="text-end" style="background-color: #b3997d;">#}
-{#        <a href="{% url 'sales_main' %}" class="btn btn-light">매장페이지</a>#}
-{#        <a href="{% url 'member_page' %}" class="btn btn-light">마이페이지</a>#}
-{#    </div>#}
-{#        <div class="logo-container" style="background-color: #b3997d;">#}
-{#            <a href="/brand" class="btn">브랜드소개</a>#}
-{#            <a href="/store" class="btn">매장안내</a>#}
-{#            <a href="/menu" class="btn">메뉴정보</a>#}
-{#            <a href="/">#}
-{#                <img src="{% static 'images/bread_im_text.png' %}" alt="text" class="logo-img">#}
-{#            </a>#}
-{#            <a href="/event" class="btn">이벤트</a>#}
-{#            <div class="btn-group">#}
-{#                <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">커뮤니티</button>#}
-{#                <ul class="dropdown-menu">#}
-{#                    <li><a class="dropdown-item" href="/notice">공지사항</a></li>#}
-{#                    <li><a class="dropdown-item" href="/qna">Q&A</a></li>#}
-{#                </ul>#}
-{#            </div>#}
-{#            {% if user.is_authenticated %}#}
-{#                <a href="{% url 'logout' %}" class="btn">Log out</a>#}
-{#            {% else %}#}
-{#                <a href="{% url 'login' %}" class="btn">Log in</a>#}
-{#                <a href="{% url 'signup' %}" class="btn">회원가입</a>#}
-{#            {% endif %}#}
-{#        </div>#}
-{#    </header>#}
-{#    <br>#}
-{#    <!--  메인 슬라이드 이미지 위 소개글 -->#}
-{#    <p class="center-text" style="font-size: {{ font_size }};">따뜻한 빵의 향기로 가득한 브레드 스캔소에 오신 것을 환영합니다!</p>#}
-{##}
-{#    <!-- 슬라이드 코드(캐러셀) -->#}
-{#    <div id="carouselExampleIndicators" class="carousel slide">#}
-{#        <div class="carousel-indicators">#}
-{#            <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>#}
-{#            <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>#}
-{#            <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2" aria-label="Slide 3"></button>#}
-{#        </div>#}
-{#        <div class="carousel-inner">#}
-{#<!--            <div class="carousel-item active d-flex justify-content-center">-->#}
-{#            <div class="carousel-item active">#}
-{#                <img src="{% static 'images/bs_main.png' %}" class="d-block custom-img" alt="메인1">#}
-{#            </div>#}
-{#            <div class="carousel-item">#}
-{#                <img src="{% static 'images/kiki.jpg' %}" class="d-block custom-img" alt="메인2">#}
-{#            </div>#}
-{#            <div class="carousel-item">#}
-{#                <img src="{% static 'images/cake.jpg' %}" class="d-block custom-img" alt="메인3">#}
-{#            </div>#}
-{#        </div>#}
-{#        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="prev">#}
-{#            <span class="carousel-control-prev-icon" aria-hidden="true"></span>#}
-{#            <span class="visually-hidden">Previous</span>#}
-{#        </button>#}
-{#        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="next">#}
-{#            <span class="carousel-control-next-icon" aria-hidden="true"></span>#}
-{#            <span class="visually-hidden">Next</span>#}
-{#        </button>#}
-{#    </div>#}
-{##}
-{#    <!-- 메인 브랜드 인사말 -->#}
-{#    <p class="center-text" style="font-size: {{ font_size }};">언제나 신선한 재료와 정성으로 만든 감동의 빵을 맛 보세요. <br>#}
-{#    매일 아침, 갓 구운 빵의 향기로 여러분을 맞이하겠습니다 ( • ᴗ - ) ✧</p>#}
-{#    <br><br>#}
-{##}
-{#    <!-- event & product 텍스트 정렬(홈(본문)) -->#}
-{#    <div class="main-header">#}
-{#        <p class="main-left fw-bold fs-4">Event</p> <!-- 좌측 정렬 -->#}
-{#        <p class="main-right fw-bold fs-4">Product</p> <!-- 우측 정렬 -->#}
-{#    </div>#}
-{##}
-{#    <div class="main-container">#}
-{#        <!-- evnet 이미지 왼쪽 정렬 -->#}
-{#        <div class="event-container">#}
-{#            <div class="event-item">#}
-{#                <img src="{% static 'images/event1.png' %}" class="event-img" alt="이벤트1">#}
-{#            </div>#}
-{#            <div class="event-item">#}
-{#                <img src="{% static 'images/event2.png' %}" class="event-img" alt="이벤트2">#}
-{#            </div>#}
-{#            <div class="event-item">#}
-{#                <img src="{% static 'images/event3.png' %}" class="event-img" alt="이벤트3">#}
-{#            </div>#}
-{#        </div>#}
-{##}
-{#        <!-- product 이미지 오른쪽 정렬 -->#}
-{#        <div class="product-container">#}
-{#            <div class="product-item">#}
-{#                <img src="{% static 'images/product1.jpg' %}" class="product-img" alt="제품1">#}
-{#            </div>#}
-{#            <div class="product-item">#}
-{#                <img src="{% static 'images/product2.jpg' %}" class="product-img" alt="제품2">#}
-{#            </div>#}
-{#            <div class="product-item">#}
-{#                <img src="{% static 'images/product3.jpg' %}" class="product-img" alt="제품3">#}
-{#            </div>#}
-{#        </div>#}
-{#    </div>#}
-{##}
-{#    <br>#}
-    {# footer #}
-{#    <footer class="text-dark py-3" style="background-color: #b3997d;">#}
-{#        <div class="container d-flex justify-content-between align-items-center">#}
-{#            <!-- 왼쪽: 영업시간 & 주소 -->#}
-{#            <div class="text-start">#}
-{#                <img src="{% static 'images/text_logo.png' %}" alt="text" class="logo-img">#}
-{#                <p class="fs-4 fw-bolder">영업시간 09:00 ~ 20:00</p>#}
-{#                <p class="fs-6">서울특별시 서초구 효령로 335</p>#}
-{#                <p class="fs-6">02)1234-5678</p>#}
-{#                <p class="fs-6">이용약관 | 개인정보처리방침</p>#}
-{#            </div>#}
-{##}
-{#            <!-- 오른쪽: SNS 링크 -->#}
-{#            <div class="text-end">#}
-{#                <p class="fs-2 fw-bolder">Follow Us</p>#}
-{#                <p class="fs-5 fw-bolder">페이스북 | 인스타그램</p>#}
-{#            </div>#}
-{#        </div>#}
-{##}
-{#        <!-- footer 센터 문구 (하단) -->#}
-{#        <div class="text-center py-3">#}
-{#            <p>&copy; 2025 BreadScanso. All rights reserved.</p>#}
-{#        </div>#}
-{#    </footer>#}
-{#</body>#}
-{#</html>#}


### PR DESCRIPTION
### member_type - page 버튼 구분
- 로그인 전 : '로그인' '회원가입'
![main](https://github.com/user-attachments/assets/c53e4f1c-84c8-49dc-84d8-ee227780d38d)
- member_type normal : '마이페이지' '로그아웃'
- member_type owner, manager : '매장페이지' '로그아웃'
    - index.html에 ```user.is_authenticated``` 일 경우, ```request.session.member_type```이 owner, manager일 경우에만 '매장페이지'와 '로그아웃'이 나오고, 아닐 경우에는 모두 '마이페이지'와 '로그아웃'이 나오도록 설정
![manager_login](https://github.com/user-attachments/assets/5ea1f365-bdee-48dc-affb-c30da9c861a8)
![member_login_1](https://github.com/user-attachments/assets/d767cdcd-a538-40e8-a88e-fe2db551f2a4)

### manager type login
- member_member 테이블에서 test5의 member_type을 'manager'로 변경 후 저장.
- test5 로그인 -> 매장페이지 클릭 시 첫 페이지를 매출관리 페이지인 'sales'로 설정
- sales appname 추가 및 반영
![store_page](https://github.com/user-attachments/assets/6376413c-ea64-426e-afa5-0efb3b63fcb4)