### PR TITLE
Feat: 매장페이지 - 결제관리에 kiosk 테이블에 저장된 주문/결제정보 반영

### DIFF
--- a/pay/urls.py
+++ b/pay/urls.py
@@ -7,8 +7,7 @@ app_name = 'pay'
 urlpatterns = [
     path('', views.pay_main, name='pay_main'),  # /pay/
 
-    path('details/', views.pay_details, name='pay_details'),
-    # path('details/<int:payment_id>/', views.pay_details, name='pay_details'),
+    path('details/<int:payment_id>/', views.pay_details, name='pay_details'),
 
     path('cancel/', views.pay_cancel, name='pay_cancel'),
 

--- a/pay/views.py
+++ b/pay/views.py
@@ -1,29 +1,68 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from kiosk.models import PaymentInfo
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 def kiosk_main(request):
     return render(request, 'kiosk/kiosk_main.html')  # kiosk_main 템플릿 파일 경로 지정
 
+
 def pay_main(request):
-    # GET 요청 처리 (member 데이터 가져오기)
     member = request.user.member
 
-    return render(request, "pay/pay_main.html", {"member": member})
+    # 로그인한 사용자의 store 값 가져오기
+    store = member.store if member.member_type == "manager" else None
+
+    # 해당 store의 결제 내역 가져오기 (store가 없으면 빈 쿼리셋 반환)
+    if store:
+        payment_infos = PaymentInfo.objects.filter(order__store=store).order_by("-pay_at")
+    else:
+        payment_infos = PaymentInfo.objects.none()  # 안전하게 빈 쿼리셋 반환
+
+    # 페이지네이션 (10개씩 표시)
+    paginator = Paginator(payment_infos, 10)  # 한 페이지당 10개씩
+    page_number = request.GET.get("page")  # 현재 페이지 번호 가져오기
+
+    try:
+        page_obj = paginator.get_page(page_number)
+    except (PageNotAnInteger, EmptyPage):
+        page_obj = paginator.get_page(1)  # 유효하지 않은 페이지 번호라면 첫 페이지로 이동
+
+    return render(request, "pay/pay_main.html", {"member": member, "page_obj": page_obj})
 
 
 # def pay_details(request, payment_id):
-def pay_details(request):
-    # payment = get_object_or_404(Purchase, id=payment_id)
-    return render(request, 'pay/pay_details.html')
-    # return render(request, 'pay/pay_details.html', {'payment': payment})
+# def pay_details(request):
+#     # payment = get_object_or_404(Purchase, id=payment_id)
+#     return render(request, 'pay/pay_details.html')
+#     # return render(request, 'pay/pay_details.html', {'payment': payment})
 
+def pay_details(request, payment_id):
+    payment = get_object_or_404(PaymentInfo, payment_id=payment_id)
+    return render(request, 'pay/pay_details.html', {'payment': payment})
+
+
+
+
+# def pay_cancel(request):
+#     # cancels = Purchase.objects.filter(is_cancelled=True).order_by("-date")
+#     # GET 요청 처리 (member 데이터 가져오기)
+#     member = request.user.member
+#
+#     return render(request, 'pay/pay_cancel.html', {"member": member})
+#     # return render(request, "pay/pay_cancel.html", {"cancels": cancels})
 
 def pay_cancel(request):
-    # cancels = Purchase.objects.filter(is_cancelled=True).order_by("-date")
-    # GET 요청 처리 (member 데이터 가져오기)
     member = request.user.member
+    store = member.store if member.member_type == "manager" else None
 
-    return render(request, 'pay/pay_cancel.html', {"member": member})
-    # return render(request, "pay/pay_cancel.html", {"cancels": cancels})
+    # 취소된 결제 내역 가져오기 (payment_status=False)
+    if store:
+        canceled_payments = PaymentInfo.objects.filter(order__store=store, payment_status=False).order_by("-pay_at")
+    else:
+        canceled_payments = []
+
+    return render(request, "pay/pay_cancel.html", {"member": member, "cancels": canceled_payments})
+
 
 def pay_member(request):
     # GET 요청 처리

--- a/templates/pay/pay_cancel.html
+++ b/templates/pay/pay_cancel.html
@@ -34,11 +34,19 @@
         <tbody>
             {% for cancel in cancels %}
             <tr style="color: red;">
-                <td>{{ cancel.date|date:"Y-m-d H:i" }}</td>
-                <td>{{ cancel.store_name }}</td>
-                <td>{{ cancel.product_name }}</td>
-                <td>{{ cancel.total_price }}</td>
-                <td>{{ cancel.payment_method }}</td>
+                <td class="clickable" data-payment-id="{{ cancel.payment_id }}">
+                    <a href="{% url 'pay:pay_details' cancel.payment_id %}">{{ cancel.pay_at|date:"Y-m-d H:i" }}</a>
+                </td>
+                <td>{{ cancel.order.store }}</td>
+                <td>{{ cancel.order.orderitem_set.first.item.item_name }}</td>
+                <td>{{ cancel.order.total_amount }}</td>
+                <td>
+                    {% if cancel.payment_method == "credit" %}
+                        <span class="badge bg-danger">카드</span>
+                    {% elif cancel.payment_method == "cash" %}
+                        <span class="badge bg-success">현금</span>
+                    {% endif %}
+                </td>
             </tr>
             {% empty %}
             <tr>
@@ -46,6 +54,7 @@
             </tr>
             {% endfor %}
         </tbody>
+
     </table>
 {% endblock content %}
 

--- a/templates/pay/pay_details.html
+++ b/templates/pay/pay_details.html
@@ -1,58 +1,38 @@
-{% extends 'layout/store/base_store.html' %}
-{% load static %}
-
-{% block title %} Pay | Details {% endblock title %}
-{% block store_id %}store_id{% endblock store_id %}
-
-{% block content %}
-    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">
-
-    <div class="receipt-container">
-        <div class="left-section">
-            <div class="receipt-header">7,000원</div>
-            <hr>
-            <p><strong>결제수단:</strong> 카드</p>
-            <p><strong>승인금액:</strong> 7,000원</p>
-            <p><strong>승인번호:</strong> 202501778</p>
-            <p><strong>승인일시:</strong> 2025-01-01 12:50:48</p>
-            <hr>
-            <p><strong>매장명:</strong> 서초동 브레드스캔스</p>
-            <p><strong>점주명:</strong> 김떡떡</p>
-            <p><strong>사업자번호:</strong> 01010101</p>
-            <p><strong>전화번호:</strong> 02-1234-1234</p>
-            <p><strong>주소:</strong> 서울 서초구 효령길12</p>
-        </div>
-        <div class="right-section">
-            <table class="table receipt-table">
-                <thead>
-                    <tr>
-                        <th>상품명</th>
-                        <th>수량</th>
-                        <th>금액</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>소금빵</td>
-                        <td>1</td>
-                        <td>3,500</td>
-                    </tr>
-                    <tr>
-                        <td>소세지빵</td>
-                        <td>1</td>
-                        <td>3,500</td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <th colspan="2">합계</th>
-                        <th>7,000</th>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
+<div class="receipt-container">
+    <div class="left-section">
+        <div class="receipt-header">{{ payment.order.total_amount }}원</div>
+        <hr>
+        <p><strong>결제수단:</strong> {{ payment.payment_method }}</p>
+        <p><strong>승인금액:</strong> {{ payment.order.total_amount }}원</p>
+        <p><strong>승인번호:</strong> {{ payment.approval_code }}</p>
+        <p><strong>승인일시:</strong> {{ payment.pay_at|date:"Y-m-d H:i:s" }}</p>
+        <hr>
+        <p><strong>매장명:</strong> {{ payment.order.store }}</p>
     </div>
-    <div class="button-container">
-        <button class="btn btn-success">확인</button>
+    <div class="right-section">
+        <table class="table receipt-table">
+            <thead>
+                <tr>
+                    <th>상품명</th>
+                    <th>수량</th>
+                    <th>금액</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in payment.order.orderitem_set.all %}
+                <tr>
+                    <td>{{ item.item.item_name }}</td>
+                    <td>{{ item.item_count }}</td>
+                    <td>{{ item.item_total }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="2">합계</th>
+                    <th>{{ payment.order.total_amount }}</th>
+                </tr>
+            </tfoot>
+        </table>
     </div>
-{% endblock content %}
+</div>

--- a/templates/pay/pay_main.html
+++ b/templates/pay/pay_main.html
@@ -42,30 +42,29 @@
             </tr>
         </thead>
         <tbody>
-            {% for purchase in purchases %}
-            <tr {% if purchase.is_cancelled %} style="color: red;" {% endif %}>
-{#                        <td class="clickable" data-id="{{ purchase.id }}">{{ purchase.date }}</td>#}
-                <td class="clickable" data-payment-id="{{ purchase.id }}">
-                    <a href="{% url 'pay_details' purchase.id %}">{{ purchase.date }}</a>
+            {% for payment in page_obj %}
+            <tr {% if not payment.payment_status %} style="color: red;" {% endif %}>
+                <td class="clickable" data-payment-id="{{ payment.payment_id }}">
+                    <a href="{% url 'pay:pay_details' payment.payment_id %}">{{ payment.pay_at|date:"Y-m-d H:i" }}</a>
                 </td>
-                <td>{{ purchase.store_name }}</td>
-                <td>{{ purchase.product_name }}</td>
-                <td>{{ purchase.quantity }}</td>
-                <td>{{ purchase.unit_price }}</td>
-                <td>{{ purchase.total_quantity }}</td>
-                <td>{{ purchase.total_price }}</td>
-                <td>{{ purchase.reward_points }}</td>
+                <td>{{ payment.order.store }}</td>
+                <td>{{ payment.order.orderitem_set.first.item.item_name }}</td>
+                <td>{{ payment.order.orderitem_set.first.item_count }}</td>
+                <td>{{ payment.order.orderitem_set.first.item_price }}</td>
+                <td>{{ payment.order.orderitem_set.count }}</td>
+                <td>{{ payment.order.total_amount }}</td>
+                <td>{{ payment.order.earned_points }}</td>
                 <td>
-                    <a href="?payment_method={{ purchase.payment_method }}">
-                        {% if purchase.payment_method == "card" %}
+                    <a href="?payment_method={{ payment.payment_method }}">
+                        {% if payment.payment_method == "credit" %}
                             <span class="badge bg-danger">카드</span>
-                        {% elif purchase.payment_method == "simple" %}
-                            <span class="badge bg-success">간편결제</span>
+                        {% elif payment.payment_method == "cash" %}
+                            <span class="badge bg-success">현금</span>
                         {% endif %}
                     </a>
                 </td>
                 <td>
-                    {% if purchase.member_status == "member" %}
+                    {% if payment.member %}
                         <span class="badge bg-primary">회원</span>
                     {% else %}
                         <span class="badge bg-warning">비회원</span>
@@ -81,22 +80,51 @@
 
     </table>
     
+    <!-- 페이지네이션 -->
+<nav aria-label="Page navigation" style="margin-top:10%;">
+    <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+            <li class="page-item">
+                <a class="page-link" href="?page=1">« First</a>
+            </li>
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.previous_page_number }}">‹ Prev</a>
+            </li>
+        {% endif %}
+
+        <li class="page-item active">
+            <span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+        </li>
+
+        {% if page_obj.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next ›</a>
+            </li>
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last »</a>
+            </li>
+        {% endif %}
+    </ul>
+</nav>
+
+
+    
     {#  하단 페이지 넘김 버튼  #}
-    <nav aria-label="..." style="margin-top:10%;">
-      <ul class="pagination">
-        <li class="page-item disabled">
-          <a class="page-link">Previous</a>
-        </li>
-        <li class="page-item active" aria-current="page">
-            <a class="page-link" href="#">1</a>
-        </li>
-        <li class="page-item"><a class="page-link" href="#">2</a></li>
-        <li class="page-item"><a class="page-link" href="#">3</a></li>
-        <li class="page-next">
-          <a class="page-link" href="#">Next</a>
-        </li>
-      </ul>
-    </nav>
+{#    <nav aria-label="..." style="margin-top:10%;">#}
+{#      <ul class="pagination">#}
+{#        <li class="page-item disabled">#}
+{#          <a class="page-link">Previous</a>#}
+{#        </li>#}
+{#        <li class="page-item active" aria-current="page">#}
+{#            <a class="page-link" href="#">1</a>#}
+{#        </li>#}
+{#        <li class="page-item"><a class="page-link" href="#">2</a></li>#}
+{#        <li class="page-item"><a class="page-link" href="#">3</a></li>#}
+{#        <li class="page-next">#}
+{#          <a class="page-link" href="#">Next</a>#}
+{#        </li>#}
+{#      </ul>#}
+{#    </nav>#}
 {% endblock content %}
 
 {% block script %}


### PR DESCRIPTION
- member_member 테이블의 member_type이 manager이고, store가 A인지 B인지 구분해서 해당 지점의 주문/결제 내역을 가져옴.
- 10행씩 보여주고, 취소내역만 따로 보여준다.
- 달력으로 기간을 정해서 조회할 수 있다.
- 결제수단, 일시, 지점, 금액, 포인트, 회원여부 등이 나온다.
- 각 결제 정보의 날짜를 클릭하면 상세 결제내역(영수증) 페이지가 나온다.

![image](https://github.com/user-attachments/assets/d91a1d07-6356-4839-9752-1eae9a04b16f)
![image](https://github.com/user-attachments/assets/ccae33bd-41db-4c9d-b042-1d635dbd68fb)
![image](https://github.com/user-attachments/assets/764e29a1-1129-4b97-add7-ee6ed17de8b1)

---

아직 취소 건을 빨간색 글씨로 나타내는 것과, 상세 페이지 구현이 제대로 되지 않았다. 페이징 처리도 다른 매장페이지와 통일되지 않았다.